### PR TITLE
feat: 스택 확장 및 페이지 폴트 핸들링 구현

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -13,6 +13,9 @@
 #include "threads/palloc.h"
 #include "threads/synch.h"
 #include "threads/init.h"
+#ifdef VM
+#include "vm/vm.h"
+#endif
 
 // true, flase define
 #define TRUE 1
@@ -129,10 +132,8 @@ static void user_memory_access(const void* addr)
         thread_exit();
     }
 #ifdef VM
-    if (spt_find_page(&thread_current()->spt, (void*)addr) == NULL) {
-        thread_current()->exit_num = -1;
-        thread_exit();
-    }
+    // 요구 페이징, 지연 로딩을 하려면 여기서 exit_num, thread_exit 하면 안되고, 최소한의 검사만 수행하고 나머지는 vm_try_handle_fault에서.
+    return;
 #else
     if (pml4_get_page(thread_current()->pml4, addr) == NULL) {
         thread_current()->exit_num = -1;
@@ -200,6 +201,16 @@ static int read(int fd, void* buffer, unsigned size)
 
     struct thread* curr = thread_current();
     struct file* file = fd_to_file_for_find(curr, fd);
+
+#ifdef VM
+    /* Writing into user buffer: if the page exists but is read-only (e.g., code),
+     * kill the process per spec. Allow missing page to fault for stack growth. */
+    struct page* p = spt_find_page(&curr->spt, buffer);
+    if (p != NULL && !p->writable) {
+        curr->exit_num = -1;
+        thread_exit();
+    }
+#endif
 
     if (file == NULL)
         return -1;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -2,11 +2,13 @@
 
 #include "threads/malloc.h"
 #include "vm/vm.h"
+#include "threads/thread.h"
 #include "vm/inspect.h"
 #include "hash.h"
 #include "threads/vaddr.h"
 #include "string.h"
 #include "userprog/process.h"
+#include <stdint.h>
 #define STACK_MAX_SIZE (1 << 20)
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
@@ -151,9 +153,13 @@ static struct frame* vm_get_frame(void)
 }
 
 /* Growing the stack. */
-static void vm_stack_growth(void* addr)
+static void vm_stack_growth(void *addr)
 {
+	void *va = pg_round_down(addr);
+	if (vm_alloc_page(VM_ANON | VM_MARKER_0, va, true))
+		vm_claim_page(va);
 }
+
 
 /* Handle the fault on write_protected page */
 static bool vm_handle_wp(struct page* page)
@@ -171,13 +177,33 @@ bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write
         return false;
     if (is_kernel_vaddr(addr))
         return false;
+    page = spt_find_page(spt, addr);
+    uintptr_t user_rsp = user ? f->rsp : thread_current()->rsp;
+
     if (not_present) {
-        page = spt_find_page(spt, addr);
-        if (page == NULL)
-            return false;
-        if (write == 1 && page->writable == 0)
-            return false;
+        if (page == NULL) {
+            bool within_stack = (addr >= USER_STACK - STACK_MAX_SIZE) && (addr < USER_STACK);
+            if (addr >= user_rsp - 8 && within_stack) {
+                vm_stack_growth(addr);
+                page = spt_find_page(spt, addr);
+                if (page == NULL)
+                    return false;
+                return vm_do_claim_page(page);
+            }
+            /* Invalid access: kill the process without printing from page_fault. */
+            thread_current()->exit_num = -1;
+            thread_exit();
+        }
+        if (write && !page->writable) {
+            thread_current()->exit_num = -1;
+            thread_exit();
+        }
         return vm_do_claim_page(page);
+    }
+    /* Present but rights violation (e.g., write to read-only). */
+    if (write && (!page || !page->writable)) {
+        thread_current()->exit_num = -1;
+        thread_exit();
     }
     return false;
 }


### PR DESCRIPTION
## 변경 사항

### 구현 내용
- **스택 확장 (Stack Growth)** 구현: 유저 스택 접근 시 페이지 폴트 발생하면 동적으로 스택 페이지 할당
- **페이지 폴트 핸들링** 개선: `vm_try_handle_fault`에서 스택 확장, 권한 검사, 지연 로딩 처리

### 변경된 파일
- `vm/vm.c`
  - `vm_stack_growth()`: 주어진 주소를 페이지 정렬 후 `VM_ANON | VM_MARKER_0` 타입으로 페이지 할당 및 claim
  - `vm_try_handle_fault()`: 
    - 스택 영역 내 접근 시 `rsp - 8` 이상이면 스택 확장 수행
    - 페이지가 없거나 쓰기 권한 없을 때 `exit_num = -1` 설정 후 종료
    - user/kernel 모드에 따라 `rsp` 값 결정 (`f->rsp` 또는 `thread_current()->rsp`)

- `userprog/syscall.c`
  - `user_memory_access()`: VM 환경에서 요구 페이징/지연 로딩을 위해 즉시 종료 대신 early return으로 변경
  - `read()`: 읽기 전용 페이지에 쓰기 시도 시 프로세스 종료 처리 추가

## 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 불필요한 주석/디버깅 코드 제거
- [x] 커밋 메시지 컨벤션 준수
- [x] 관련 테스트 통과 확인

## 추가 설명
- 스택 최대 크기는 1MB (`STACK_MAX_SIZE = 1 << 20`)로 제한
- 시스템 콜 진입 시 `thread_current()->rsp`에 유저 스택 포인터 저장 필요 (커널 모드에서 페이지 폴트 처리 시 사용)