### PR TITLE
feat: stack_grow 구현

### DIFF
--- a/pintos/userprog/exception.c
+++ b/pintos/userprog/exception.c
@@ -141,6 +141,8 @@ static void page_fault(struct intr_frame* f)
 #endif
     /* Count page faults. */
     page_fault_cnt++;
+    thread_current()->exit_num = -1;
+    thread_exit();
     /* If the fault is true fault, show info and exit. */
     printf("Page fault at %p: %s error %s page in %s context.\n", fault_addr,
            not_present ? "not present" : "rights violation", write ? "writing" : "reading", user ? "user" : "kernel");

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -129,10 +129,10 @@ static void user_memory_access(const void* addr)
         thread_exit();
     }
 #ifdef VM
-    if (spt_find_page(&thread_current()->spt, (void*)addr) == NULL) {
-        thread_current()->exit_num = -1;
-        thread_exit();
-    }
+    // if (spt_find_page(&thread_current()->spt, (void*)addr) == NULL) {
+    //     thread_current()->exit_num = -1;
+    //     thread_exit();
+    // }
 #else
     if (pml4_get_page(thread_current()->pml4, addr) == NULL) {
         thread_current()->exit_num = -1;
@@ -201,6 +201,11 @@ static int read(int fd, void* buffer, unsigned size)
     struct thread* curr = thread_current();
     struct file* file = fd_to_file_for_find(curr, fd);
 
+    struct page* page = spt_find_page(&curr->spt, buffer);
+    if (page && !page->writable) {
+        thread_current()->exit_num = -1;
+        thread_exit();
+    }
     if (file == NULL)
         return -1;
     if (file != stdin_f && file != stdout_f) {


### PR DESCRIPTION
## 변경 사항

### 구현 내용
<!-- 구현내용에 대해서 설명해주세요. -->
<!-- 예시:
- Priority Scheduling 구현: ready_list를 우선순위 기반으로 관리 
-->
- `vm_stack_growth` 함수 구현
- `vm_try_handle_fault ` `vm_stack_growth`이 가능하게 추가
-  `thread.h ` thread 구조체에 rsp 필드 추가
- ` syscall.c `일부 수정
### 변경된 파일
<!-- 구현 내용으로 인해 변경된 파일에 대해 설명해주세요 -->
<!-- 예시:
- `threads/thread.c`
  - 코드 컨벤션에 맞춰 포매팅 적용
  - `cmp_thread_priority()` 함수를 전역 함수로 변경 (세마포어에서 사용)
  - `thread_unblock()`: 우선순위 순으로 ready_list에 삽입
  - `thread_yield()`: 우선순위 순으로 ready_list에 삽입
  - `thread_create()`: 생성된 스레드가 현재 스레드보다 높은 우선순위면 즉시 선점
  - `thread_set_priority()`: `original_priority` 갱신 후 `refresh_priority()` 호출, ready_list 검사 후 필요시 양보
  - `refresh_priority()` 함수 추가: donation 리스트에서 최고 우선순위로 현재 우선순위 갱신
 -->
-vm.c 에서 `vm_try_handle_fault ` 에서 스택 증가에 적합한 사례이면 스택증가로 폴트 처리
- 유저모드에서 발생한거면 intr frame -> rsp를, 커널모드에서 발생한거면 커널모드 들어오면서 저장한 thread->rsp를 사용
- 스택 성장의 적합함 판단은 rsp가 유저스택포인터로 부터 최대 1Mb정도 내려갔는지를 확인, addr은 user_stack보다 작은지, 그리고 rsp보다 위에있는지 (rsp가 더 작은지)
- syscall.c에 유저메모리 엑세스 함수에서 스택 그로우할때 spt에 없는거 전부 exit 처리하는 문제 발생. 없애니까 해결 
## 체크리스트
<!-- 체크리스트를 모두 완료한 후 제출해주세요 -->
<!-- 완료 처리를 표시하려면 [x], 완료되지 않았다면 [ ] -->
- [x] 코드 스타일 가이드 준수
- [x] 불필요한 주석/디버깅 코드 제거
- [x] 커밋 메시지 컨벤션 준수
- [ ] 관련 테스트 통과 확인

## 추가 설명
<!-- 추가로 설명할 내용이 있으시다면 아래에 작성해주세요. -->