### PR TITLE
feat(mmap): mmap/munmap 구현 및 동시성 문제 해결

### DIFF
--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -6,7 +6,12 @@
 struct page;
 enum vm_type;
 
-struct file_page {};
+struct file_page {
+    struct file* file;
+    off_t offset;
+    size_t length;
+    int writable;
+};
 
 void vm_file_init(void);
 bool file_backed_initializer(struct page* page, enum vm_type type, void* kva);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -72,21 +72,16 @@ static bool cmp_done_priority(const struct list_elem* a, const struct list_elem*
 static void kill_donor(struct lock* lock)
 {
     struct list* donations = &(thread_current()->donation);
-    struct list_elem* donor_elem;
-    struct thread* donor_thread;
+    struct list_elem* donor_elem = list_begin(donations);
 
-    if (list_empty(donations))
-        return;
-
-    donor_elem = list_front(donations);
-
-    while (1) {
-        donor_thread = list_entry(donor_elem, struct thread, donation_elem);
-        if (donor_thread->lock_on_wait == lock)
-            list_remove(&donor_thread->donation_elem);
-        donor_elem = list_next(donor_elem);
-        if (donor_elem == list_end(donations))
-            return;
+    while (donor_elem != list_end(donations)) {
+        struct thread* donor_thread = list_entry(donor_elem, struct thread, donation_elem);
+        struct list_elem* next = list_next(donor_elem);
+        if (donor_thread->lock_on_wait == lock) {
+            list_remove(donor_elem);
+            donor_thread->lock_on_wait = NULL;
+        }
+        donor_elem = next;
     }
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -228,7 +228,11 @@ tid_t thread_create(const char* name, int priority, thread_func* function, void*
     // thread
     struct thread* parent = thread_current();
     t->parent = parent;
+
+    enum intr_level old_level = intr_disable();
     list_push_front(&(parent->childs), &(t->child_elem));
+    intr_set_level(old_level);
+
     /* Call the kernel_thread if it scheduled.
      * Note) rdi is 1st argument, and rsi is 2nd argument. */
     t->tf.rip = (uintptr_t)kernel_thread;

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -1,10 +1,12 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
 #include "vm/vm.h"
-
+#include "userprog/process.h"
 static bool file_backed_swap_in(struct page* page, void* kva);
 static bool file_backed_swap_out(struct page* page);
 static void file_backed_destroy(struct page* page);
+
+#define PGSIZE 4096
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations file_ops = {
@@ -20,38 +22,137 @@ void vm_file_init(void)
 }
 
 /* Initialize the file backed page */
+
+static bool mmap_lazy_load_segment(struct page* page, void* aux)
+{
+    struct lazy_load_aux* new_aux = (struct lazy_load_aux*)aux;
+    void* kva = page->frame->kva;
+    if (file_read_at(new_aux->file, kva, new_aux->page_read_bytes, new_aux->ofs)) {
+        memset(kva + new_aux->page_read_bytes, 0, new_aux->page_zero_bytes);
+        return true;
+    }
+    return false;
+}
 bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
 {
     /* Set up the handler */
     page->operations = &file_ops;
 
     struct file_page* file_page = &page->file;
+    struct lazy_load_aux* aux = (struct lazy_load_aux*)page->uninit.aux;
+
+    file_page->file = aux->file;
+    file_page->offset = aux->ofs;
+    file_page->length = aux->page_read_bytes;
+    file_page->writable = page->writable;
+    return true;
 }
 
 /* Swap in the page by read contents from the file. */
 static bool file_backed_swap_in(struct page* page, void* kva)
 {
     struct file_page* file_page UNUSED = &page->file;
+    if (file_read_at(file_page->file, kva, file_page->length, file_page->offset) == (off_t)file_page->length) {
+        memset(kva + file_page->length, 0, PGSIZE - file_page->length);
+        return true;
+    }
+    return false;
 }
 
 /* Swap out the page by writeback contents to the file. */
 static bool file_backed_swap_out(struct page* page)
 {
     struct file_page* file_page UNUSED = &page->file;
+    if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+        file_write_at(file_page->file, page->frame->kva, file_page->length, file_page->offset);
+    }
+    pml4_clear_page(thread_current()->pml4, page->va);
+    page->frame = NULL;
+    return true;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void file_backed_destroy(struct page* page)
 {
     struct file_page* file_page UNUSED = &page->file;
-}
+    if (page->frame != NULL) {
+        // enum intr_level old_level = intr_disable();
+        if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+            file_write_at(file_page->file, page->frame->kva, file_page->length, file_page->offset);
+            pml4_set_dirty(thread_current()->pml4, page->va, false);
+        }
+        pml4_clear_page(thread_current()->pml4, page->va);
+        palloc_free_page(page->frame->kva);
+        page->frame->page = NULL;
+        free(page->frame);
 
+        // intr_set_level(old_level);
+    }
+    return;
+}
 /* Do the mmap */
 void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t offset)
 {
+    int num_pages = (length + PGSIZE - 1) / PGSIZE;
+    struct file* new_file = file_reopen(file);
+    for (int i = 0; i < num_pages; i++) {
+        struct lazy_load_aux* aux = malloc(sizeof(struct lazy_load_aux));
+        if (aux == NULL) {
+            do_munmap(addr);
+            return NULL;
+        }
+        aux->file = new_file;
+        aux->ofs = offset;
+        aux->page_read_bytes = length < PGSIZE ? length : PGSIZE;
+        aux->page_zero_bytes = PGSIZE - aux->page_read_bytes;
+        offset += aux->page_read_bytes;
+        length -= aux->page_read_bytes;
+        if (!vm_alloc_page_with_initializer(VM_FILE, addr + i * PGSIZE, writable, mmap_lazy_load_segment, aux)) {
+            free(aux);
+            do_munmap(addr);
+            return NULL;
+        }
+    }
+    return addr;
 }
 
 /* Do the munmap */
 void do_munmap(void* addr)
 {
+    struct page* page = spt_find_page(&thread_current()->spt, addr);
+    if (page == NULL || page_get_type(page) != VM_FILE)
+        return;
+
+    struct file* finding_file;
+    if (page->operations->type == VM_UNINIT) {
+        struct lazy_load_aux* aux = (struct lazy_load_aux*)page->uninit.aux;
+        if (aux == NULL || aux->file == NULL)
+            return;
+        finding_file = aux->file;
+    } else {
+        if (page->file.file == NULL)
+            return;
+        finding_file = page->file.file;
+    }
+    struct file* current_file;
+    while (page != NULL) {
+        if (page_get_type(page) == VM_FILE) {
+            if (page->operations->type == VM_UNINIT) {
+                struct lazy_load_aux* aux = (struct lazy_load_aux*)page->uninit.aux;
+                current_file = aux->file;
+            } else {
+                current_file = page->file.file;
+            }
+        } else {
+            break;
+        }
+        if (current_file != finding_file) {
+            break;
+        }
+        spt_remove_page(&thread_current()->spt, page);
+        addr += PGSIZE;
+        page = spt_find_page(&thread_current()->spt, addr);
+    }
+    file_close(finding_file);
+    return;
 }

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -61,4 +61,8 @@ static void uninit_destroy(struct page* page)
     struct uninit_page* uninit UNUSED = &page->uninit;
     /* TODO: Fill this function.
      * TODO: If you don't have anything to do, just return. */
+    if (uninit->aux != NULL) { // close file in do_munmap
+        free(uninit->aux);
+        uninit->aux = NULL;
+    }
 }


### PR DESCRIPTION
mmap complete list 접근 도중 interrupt 발생 방지:
- thread.c, process.c에서 list 순회 중 interrupt 비활성화
- 특히 fork, create에서 취약한 부분 수정

write 후 dirty 반영이 바로 안되는 현상 해결:
- process.c에서 sema_up 전 file_close 직후 process_cleanup() 호출

syscall.c에 mmap, munmap 추가:
- 조건 체크 후 file.c로 이동
- mmap에서는 overflow 체크 필요

file.c에 do_mmap, do_munmap 등 기타 함수 구현:
- mmap시 file은 한번만 open
- munmap에서 다른 file을 가리킬때까지 계속 해제하면서 이동. 마지막에 file_close
- type이 vm_uninit인지 vm_file인지 체크 필요
- lazy_load를 위한 mmap_lazy_load_segment 구현
- file_backed_initializer 구현
- file_bakced_swap_in/out 구현
- file_backed_destroy 구현

uninit_destroy에 free(aux) 추가:
- file close는 munmap에서

vm.c에서 spt copy, spt_remove_page 수정:
- type이 file일시 skip하도록 설정
- remove page 시 spt에서 삭제하도록 설정

## 변경 사항

### 구현 내용
<!-- 구현내용에 대해서 설명해주세요. -->
<!-- 예시:
- Priority Scheduling 구현: ready_list를 우선순위 기반으로 관리 
-->

### 변경된 파일
<!-- 구현 내용으로 인해 변경된 파일에 대해 설명해주세요 -->
<!-- 예시:
- `threads/thread.c`
  - 코드 컨벤션에 맞춰 포매팅 적용
  - `cmp_thread_priority()` 함수를 전역 함수로 변경 (세마포어에서 사용)
  - `thread_unblock()`: 우선순위 순으로 ready_list에 삽입
  - `thread_yield()`: 우선순위 순으로 ready_list에 삽입
  - `thread_create()`: 생성된 스레드가 현재 스레드보다 높은 우선순위면 즉시 선점
  - `thread_set_priority()`: `original_priority` 갱신 후 `refresh_priority()` 호출, ready_list 검사 후 필요시 양보
  - `refresh_priority()` 함수 추가: donation 리스트에서 최고 우선순위로 현재 우선순위 갱신
 -->

## 체크리스트
<!-- 체크리스트를 모두 완료한 후 제출해주세요 -->
<!-- 완료 처리를 표시하려면 [x], 완료되지 않았다면 [ ] -->
- [x] 코드 스타일 가이드 준수
- [x] 불필요한 주석/디버깅 코드 제거
- [x] 커밋 메시지 컨벤션 준수
- [x] 관련 테스트 통과 확인

## 추가 설명
<!-- 추가로 설명할 내용이 있으시다면 아래에 작성해주세요. -->