### PR TITLE
Feat(vm): Memory Mapped File (mmap/munmap) 구현 및 Fork 안전성 강화

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -3,6 +3,7 @@
 
 #include <debug.h>
 #include <list.h>
+#include <stddef.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
 #include "threads/synch.h"
@@ -139,11 +140,19 @@ struct thread {
     /* Table for whole virtual memory owned by thread. */
     struct supplemental_page_table spt;
     uintptr_t rsp;
+    struct list mmap_list;
 #endif
 
     /* Owned by thread.c. */
     struct intr_frame tf; /* Information for switching */
     unsigned magic;       /* Detects stack overflow. */
+};
+
+struct mmap_data {
+    void* addr;
+    size_t page_cnt;
+    struct file* file;
+    struct list_elem mmap_elem;
 };
 
 /* If false (default), use round-robin scheduler.

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -9,12 +9,7 @@ int process_exec(void* f_name);
 int process_wait(tid_t);
 void process_exit(void);
 void process_activate(struct thread* next);
-struct lazy_load_aux {
-    struct file* file;
-    off_t ofs;
-    size_t page_read_bytes;
-    size_t page_zero_bytes;
-};
+
 #ifdef VM
 #include "vm/vm.h"
 bool lazy_load_segment(struct page *page, void *aux);

--- a/pintos/include/userprog/process.h
+++ b/pintos/include/userprog/process.h
@@ -15,5 +15,9 @@ struct lazy_load_aux {
     size_t page_read_bytes;
     size_t page_zero_bytes;
 };
+#ifdef VM
+#include "vm/vm.h"
+bool lazy_load_segment(struct page *page, void *aux);
+#endif
 
 #endif /* userprog/process.h */

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -8,8 +8,8 @@ enum vm_type;
 struct file_page {
     struct file* file;
     off_t ofs;
-    size_t read_bytes;
-    size_t zero_bytes;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
 };
 
 void vm_file_init(void);

--- a/pintos/include/vm/file.h
+++ b/pintos/include/vm/file.h
@@ -1,12 +1,16 @@
 #ifndef VM_FILE_H
 #define VM_FILE_H
 #include "filesys/file.h"
-#include "vm/vm.h"
 
 struct page;
 enum vm_type;
 
-struct file_page {};
+struct file_page {
+    struct file* file;
+    off_t ofs;
+    size_t read_bytes;
+    size_t zero_bytes;
+};
 
 void vm_file_init(void);
 bool file_backed_initializer(struct page* page, enum vm_type type, void* kva);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -72,21 +72,16 @@ static bool cmp_done_priority(const struct list_elem* a, const struct list_elem*
 static void kill_donor(struct lock* lock)
 {
     struct list* donations = &(thread_current()->donation);
-    struct list_elem* donor_elem;
-    struct thread* donor_thread;
+    struct list_elem* donor_elem = list_begin(donations);
 
-    if (list_empty(donations))
-        return;
-
-    donor_elem = list_front(donations);
-
-    while (1) {
-        donor_thread = list_entry(donor_elem, struct thread, donation_elem);
-        if (donor_thread->lock_on_wait == lock)
-            list_remove(&donor_thread->donation_elem);
-        donor_elem = list_next(donor_elem);
-        if (donor_elem == list_end(donations))
-            return;
+    while (donor_elem != list_end(donations)) {
+        struct thread* donor_thread = list_entry(donor_elem, struct thread, donation_elem);
+        struct list_elem* next = list_next(donor_elem);
+        if (donor_thread->lock_on_wait == lock) {
+            list_remove(donor_elem);
+            donor_thread->lock_on_wait = NULL;
+        }
+        donor_elem = next;
     }
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -10,6 +10,7 @@
 #include "threads/palloc.h"
 #include "threads/synch.h"
 #include "threads/vaddr.h"
+#include "threads/malloc.h"
 #include "intrinsic.h"
 #include "fixed-point.h"
 #include "threads/init.h"
@@ -206,7 +207,6 @@ tid_t thread_create(const char* name, int priority, thread_func* function, void*
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
 
-    // 하....,,,,,....
     struct descriptor* stdin_descript = calloc(1, sizeof(struct descriptor));
     if (stdin_descript == NULL) {
         return -1;
@@ -633,6 +633,7 @@ static void init_thread(struct thread* t, const char* name, int priority)
     t->exit_num = 0;
     list_init(&(t->descrs_t));
     list_init(&(t->childs));
+    list_init(&(t->mmap_list));
     t->parent = NULL;
     sema_init(&t->wait, 0);
     sema_init(&t->load, 0);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -388,6 +388,17 @@ void thread_exit(void)
 #ifdef USERPROG
     process_exit();
 #endif
+    /* Clean up donation links to avoid dangling pointers. */
+    struct thread* cur = thread_current();
+    /* If we are waiting on some lock, detach our donation_elem from its holder. */
+    if (cur->lock_on_wait != NULL)
+        list_remove(&cur->donation_elem);
+    /* Remove all donor entries pointing to us. */
+    while (!list_empty(&cur->donation)) {
+        struct list_elem* e = list_pop_front(&cur->donation);
+        struct thread* donor = list_entry(e, struct thread, donation_elem);
+        donor->lock_on_wait = NULL;
+    }
 
     /* Just set our status to dying and schedule another process.
        We will be destroyed during the call to schedule_tail(). */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -732,7 +732,7 @@ static bool install_page(void* upage, void* kpage, bool writable)
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
-static bool lazy_load_segment(struct page* page, void* aux)
+bool lazy_load_segment(struct page* page, void* aux) // 
 {
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -213,9 +213,8 @@ static void __do_fork(void* aux)
             else
                 dup_file = parent_descript->file;
             struct descriptor* child_descript = calloc(1, sizeof(struct descriptor));
-            if (child_descript == NULL) {
+            if (child_descript == NULL)
                 goto error;
-            }
             child_descript->fd = parent_descript->fd;
             child_descript->file = dup_file;
             child_descript->file->refcnt++;
@@ -307,6 +306,11 @@ void process_exit(void)
      * TODO: Implement process termination message (see
      * TODO: project2/process_termination.html).
      * TODO: We recommend you to implement process resource cleanup here. */
+    /* If we are dying while holding the filesys_lock (e.g., fault during sys_open),
+       release it to avoid self-deadlock/assertion on cleanup. */
+    if (lock_held_by_current_thread(&filesys_lock))
+        lock_release(&filesys_lock);
+
     if (curr->pml4 == NULL) {
         return;
     }
@@ -320,10 +324,12 @@ void process_exit(void)
     }
 
     while (!list_empty(&curr->childs)) {
+        enum intr_level old_level = intr_disable();
         struct list_elem* e = list_begin(&curr->childs);
         struct thread* child = list_entry(e, struct thread, child_elem);
 
         list_remove(e);
+        intr_set_level(old_level);
         sema_up(&child->waiting_parents);
     }
 
@@ -339,7 +345,7 @@ void process_exit(void)
 
     if (curr->parent != NULL)
         sema_down(&curr->waiting_parents);
-    
+
     process_cleanup();
     hash_destroy(&curr->spt.hash_table, NULL);
 }
@@ -746,7 +752,7 @@ bool lazy_load_segment(struct page* page, void* aux) //
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */
     /* TODO: VA is available when calling this function. */
-    struct lazy_load_aux* arg = (struct lazy_load_aux*)aux;
+    struct file_page* arg = (struct file_page*)aux;
     bool flag = false;
     if (!lock_held_by_current_thread(&filesys_lock)) {
         lock_acquire(&filesys_lock);
@@ -794,16 +800,16 @@ static bool load_segment(struct file* file, off_t ofs, uint8_t* upage, uint32_t 
         size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
         /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        struct lazy_load_aux* lazy_load_aux = malloc(sizeof(struct lazy_load_aux));
-        if (lazy_load_aux == NULL)
+        struct file_page* file_page_aux = malloc(sizeof(struct file_page));
+        if (file_page_aux == NULL)
             return false;
-        lazy_load_aux->file = file;
-        lazy_load_aux->ofs = ofs;
-        lazy_load_aux->page_read_bytes = page_read_bytes;
-        lazy_load_aux->page_zero_bytes = page_zero_bytes;
+        file_page_aux->file = file;
+        file_page_aux->ofs = ofs;
+        file_page_aux->page_read_bytes = page_read_bytes;
+        file_page_aux->page_zero_bytes = page_zero_bytes;
 
-        if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, lazy_load_aux)) {
-            free(lazy_load_aux);
+        if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, file_page_aux)) {
+            free(file_page_aux);
             return false;
         }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -24,6 +24,7 @@
 
 #ifdef VM
 #include "vm/vm.h"
+#include "vm/file.h"
 #endif
 
 static void process_cleanup(void);
@@ -326,11 +327,19 @@ void process_exit(void)
         sema_up(&child->waiting_parents);
     }
 
+    // mmap된 모든 매핑 해제 (dirty page write back) - pml4가 유효할 때 해야 함
+    while (!list_empty(&curr->mmap_list)) {
+        struct list_elem* e = list_begin(&curr->mmap_list);
+        struct mmap_data* md = list_entry(e, struct mmap_data, mmap_elem);
+        do_munmap(md->addr);
+    }
+
     file_close(curr->exec_file);
     sema_up(&curr->wait);
 
     if (curr->parent != NULL)
         sema_down(&curr->waiting_parents);
+    
     process_cleanup();
     hash_destroy(&curr->spt.hash_table, NULL);
 }
@@ -746,7 +755,7 @@ bool lazy_load_segment(struct page* page, void* aux) //
     if (file_read_at(arg->file, page->frame->kva, arg->page_read_bytes, arg->ofs) != (int)arg->page_read_bytes) {
         if (flag)
             lock_release(&filesys_lock);
-        palloc_free_page(page);
+        palloc_free_page(page->frame->kva);
         return false;
     }
     if (flag)

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -103,8 +103,11 @@ int fd_to_file_for_remove(struct thread* curr, int fd)
             // 여기 주의
             if (descript->file != stdin_f && descript->file != stdout_f) {
                 descript->file->refcnt--;
-                if (descript->file->refcnt < 1)
+                if (descript->file->refcnt < 1) {
+                    lock_acquire(&filesys_lock);
                     file_close(descript->file);
+                    lock_release(&filesys_lock);
+                }
             }
             free(descript);
             return true;
@@ -187,6 +190,7 @@ static int open(const char* file_name)
     struct descriptor* descript = calloc(1, sizeof(struct descriptor));
     if (descript == NULL) {
         file_close(file);
+        lock_release(&filesys_lock);
         return -1;
     }
     descript->fd = fd;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,9 +1,11 @@
 #include "userprog/syscall.h"
 #include <stdio.h>
 #include <syscall-nr.h>
+#include "stddef.h"
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 #include "threads/loader.h"
+#include "threads/vaddr.h"
 #include "userprog/gdt.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
@@ -13,6 +15,10 @@
 #include "threads/palloc.h"
 #include "threads/synch.h"
 #include "threads/init.h"
+#include "vm/file.h"
+#ifdef VM
+#include "vm/vm.h"
+#endif
 
 // true, flase define
 #define TRUE 1
@@ -328,6 +334,25 @@ static unsigned int tell(int fd)
     return -1;
 }
 
+static void* mmap(int fd, void* addr, size_t length, int writable, off_t offset)
+{ // P3 mmap 설명: On failure, it must return NULL which is not a valid address to map a file.
+    if (fd < 2 || addr == NULL || pg_ofs(addr) != 0 || length == 0 || is_kernel_vaddr(addr))
+        return NULL;
+    struct file* file = fd_to_file_for_find(thread_current(), fd);
+    if (file == NULL)
+        return NULL;
+    return do_mmap(addr, length, writable, file, offset);
+}
+
+static void munmap(void* addr)
+{
+    user_memory_access(addr);
+    if (pg_ofs(addr) != 0)
+        return;
+    do_munmap(addr);
+}
+
+
 /* The main system call interface */
 void syscall_handler(struct intr_frame* f)
 {
@@ -395,6 +420,12 @@ void syscall_handler(struct intr_frame* f)
         break;
     case SYS_TELL:
         f->R.rax = tell(f->R.rdi);
+        break;
+    case SYS_MMAP:
+        f->R.rax = (uint64_t)mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
+        break;
+    case SYS_MUNMAP:
+        munmap(f->R.rdi);
         break;
     default:
         NOT_REACHED();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -338,6 +338,13 @@ static void* mmap(int fd, void* addr, size_t length, int writable, off_t offset)
 { // P3 mmap 설명: On failure, it must return NULL which is not a valid address to map a file.
     if (fd < 2 || addr == NULL || pg_ofs(addr) != 0 || length == 0 || is_kernel_vaddr(addr))
         return NULL;
+    // offset이 페이지 정렬되어 있지 않으면 실패
+    if (pg_ofs((void*)offset) != 0)
+        return NULL;
+    // addr + length가 커널 영역에 도달하거나 오버플로우하면 실패
+    void* end_addr = (void*)((uintptr_t)addr + length);
+    if (end_addr <= addr || is_kernel_vaddr(end_addr) || is_kernel_vaddr((void*)((uintptr_t)end_addr - 1)))
+        return NULL;
     struct file* file = fd_to_file_for_find(thread_current(), fd);
     if (file == NULL)
         return NULL;
@@ -422,7 +429,7 @@ void syscall_handler(struct intr_frame* f)
         f->R.rax = tell(f->R.rdi);
         break;
     case SYS_MMAP:
-        f->R.rax = (uint64_t)mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
+        f->R.rax = (uint64_t)mmap(f->R.r10, f->R.rdi, f->R.rsi, f->R.rdx, f->R.r8);
         break;
     case SYS_MUNMAP:
         munmap(f->R.rdi);

--- a/pintos/vm/anon.c
+++ b/pintos/vm/anon.c
@@ -2,6 +2,7 @@
 
 #include "vm/vm.h"
 #include "devices/disk.h"
+#include "threads/mmu.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk* swap_disk;
@@ -49,4 +50,15 @@ static bool anon_swap_out(struct page* page)
 static void anon_destroy(struct page* page)
 {
     struct anon_page* anon_page = &page->anon;
+    struct thread* cur = thread_current();
+    
+    /* frame이 할당되어 있으면 해제 */
+    if (page->frame != NULL)
+    {
+        /* pml4에서 매핑 해제 (pml4_destroy에서 double free 방지) */
+        pml4_clear_page(cur->pml4, page->va);
+        palloc_free_page(page->frame->kva);
+        free(page->frame);
+        page->frame = NULL;
+    }
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -32,7 +32,7 @@ void vm_file_init(void)
 bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
 {
     /* uninit에서 넘어온 aux 정보를 먼저 저장 (page->operations 변경 전에) */
-    struct lazy_load_aux* aux = (struct lazy_load_aux*)page->uninit.aux;
+    struct file_page* aux = (struct file_page*)page->uninit.aux;
     
     /* Set up the handler */
     page->operations = &file_ops;
@@ -40,8 +40,8 @@ bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
     struct file_page* file_page = &page->file;
     file_page->file = aux->file;
     file_page->ofs = aux->ofs;
-    file_page->read_bytes = aux->page_read_bytes;
-    file_page->zero_bytes = aux->page_zero_bytes;
+    file_page->page_read_bytes = aux->page_read_bytes;
+    file_page->page_zero_bytes = aux->page_zero_bytes;
 
     return true;
 }
@@ -52,10 +52,13 @@ static bool file_backed_swap_in(struct page* page, void* kva)
     struct file_page* file_page = &page->file;
     
     lock_acquire(&filesys_lock);
-    file_read_at(file_page->file, kva, file_page->read_bytes, file_page->ofs);
+    off_t read_bytes = file_read_at(file_page->file, kva, file_page->page_read_bytes, file_page->ofs);
     lock_release(&filesys_lock);
+
+    if (read_bytes != (int)file_page->page_read_bytes)
+        return false;
     
-    memset(kva + file_page->read_bytes, 0, file_page->zero_bytes);
+    memset(kva + file_page->page_read_bytes, 0, file_page->page_zero_bytes);
     return true;
 }
 
@@ -69,7 +72,7 @@ static bool file_backed_swap_out(struct page* page)
     if (pml4_is_dirty(cur->pml4, page->va))
     {
         lock_acquire(&filesys_lock);
-        file_write_at(file_page->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+        file_write_at(file_page->file, page->frame->kva, file_page->page_read_bytes, file_page->ofs);
         lock_release(&filesys_lock);
         pml4_set_dirty(cur->pml4, page->va, false);
     }
@@ -90,7 +93,7 @@ static void file_backed_destroy(struct page* page)
     if (page->frame != NULL && pml4_is_dirty(cur->pml4, page->va))
     {
         lock_acquire(&filesys_lock);
-        file_write_at(file_page->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+        file_write_at(file_page->file, page->frame->kva, file_page->page_read_bytes, file_page->ofs);
         lock_release(&filesys_lock);
     }
     
@@ -120,14 +123,16 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         return NULL;
     }
     size_t file_len = file_length(reopened_file);
-    if (file_len == 0) {
+    /* offset이 파일 끝을 넘거나 파일 길이가 0이면 실패 */
+    if (file_len == 0 || (off_t)file_len <= offset) {
+        file_close(reopened_file);
         lock_release(&filesys_lock);
         return NULL;
     }
+    size_t available_len = file_len - offset;
+    /* 실제 매핑할 길이는 파일 길이와 요청 길이 중 작은 값 (offset 반영) */
+    size_t map_length = length < available_len ? length : available_len;
     lock_release(&filesys_lock);
-
-    // 실제 매핑할 길이는 파일 길이와 요청 길이 중 작은 값
-    size_t map_length = length < file_len ? length : file_len;
 
     // 2. 페이지 수 계산
     size_t page_cnt = map_length / PGSIZE + (map_length % PGSIZE != 0 ? 1 : 0);
@@ -160,6 +165,7 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
 
     // 5. 페이지 할당 루프 (lazy loading)
     size_t remain_bytes = map_length;
+    size_t allocated_pages = 0;
 
     for (size_t i = 0; i < page_cnt; i++)
     {
@@ -167,13 +173,9 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         size_t read_bytes = remain_bytes < PGSIZE ? remain_bytes : PGSIZE;
         size_t zero_bytes = PGSIZE - read_bytes;
 
-        struct lazy_load_aux* aux = malloc(sizeof(struct lazy_load_aux));
+        struct file_page* aux = malloc(sizeof(struct file_page));
         if (aux == NULL) {
-            free(m_data);
-            lock_acquire(&filesys_lock);
-            file_close(reopened_file);
-            lock_release(&filesys_lock);
-            return NULL;
+            goto mmap_fail;
         }
 
         aux->file = reopened_file;
@@ -184,16 +186,30 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, lazy_load_segment, aux))
         {
             free(aux);
-            free(m_data);
-            lock_acquire(&filesys_lock);
-            file_close(reopened_file);
-            lock_release(&filesys_lock);
-            return NULL;
+            goto mmap_fail;
         }
 
+        allocated_pages++;
         remain_bytes -= read_bytes;
     }
+    goto mmap_success;
 
+mmap_fail:
+    /* 이전에 할당된 페이지들 정리 */
+    for (size_t i = 0; i < allocated_pages; i++)
+    {
+        void* va = addr + (i * PGSIZE);
+        struct page* page = spt_find_page(&cur->spt, va);
+        if (page != NULL)
+            spt_remove_page(&cur->spt, page);
+    }
+    free(m_data);
+    lock_acquire(&filesys_lock);
+    file_close(reopened_file);
+    lock_release(&filesys_lock);
+    return NULL;
+
+mmap_success:
     // 6. mmap_list에 추가 후 성공 반환
     list_push_back(&cur->mmap_list, &m_data->mmap_elem);
     return addr;
@@ -234,7 +250,7 @@ void do_munmap(void* addr)
         {
             struct file_page* file_page = &page->file;
             lock_acquire(&filesys_lock);
-            file_write_at(m_data->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+            file_write_at(m_data->file, page->frame->kva, file_page->page_read_bytes, file_page->ofs);
             lock_release(&filesys_lock);
         }
 

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -1,6 +1,15 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
+#include "list.h"
+#include "stddef.h"
+#include "threads/mmu.h"
+#include "threads/synch.h"
+#include "threads/vaddr.h"
 #include "vm/vm.h"
+#include "userprog/syscall.h"
+#include "threads/malloc.h"
+#include "userprog/process.h"
+#include "string.h"
 
 static bool file_backed_swap_in(struct page* page, void* kva);
 static bool file_backed_swap_out(struct page* page);
@@ -22,36 +31,223 @@ void vm_file_init(void)
 /* Initialize the file backed page */
 bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
 {
+    /* uninit에서 넘어온 aux 정보를 먼저 저장 (page->operations 변경 전에) */
+    struct lazy_load_aux* aux = (struct lazy_load_aux*)page->uninit.aux;
+    
     /* Set up the handler */
     page->operations = &file_ops;
 
     struct file_page* file_page = &page->file;
+    file_page->file = aux->file;
+    file_page->ofs = aux->ofs;
+    file_page->read_bytes = aux->page_read_bytes;
+    file_page->zero_bytes = aux->page_zero_bytes;
+
+    return true;
 }
 
 /* Swap in the page by read contents from the file. */
 static bool file_backed_swap_in(struct page* page, void* kva)
 {
-    struct file_page* file_page UNUSED = &page->file;
+    struct file_page* file_page = &page->file;
+    
+    lock_acquire(&filesys_lock);
+    file_read_at(file_page->file, kva, file_page->read_bytes, file_page->ofs);
+    lock_release(&filesys_lock);
+    
+    memset(kva + file_page->read_bytes, 0, file_page->zero_bytes);
+    return true;
 }
 
 /* Swap out the page by writeback contents to the file. */
 static bool file_backed_swap_out(struct page* page)
 {
-    struct file_page* file_page UNUSED = &page->file;
+    struct file_page* file_page = &page->file;
+    struct thread* cur = thread_current();
+    
+    // dirty면 파일에 write back
+    if (pml4_is_dirty(cur->pml4, page->va))
+    {
+        lock_acquire(&filesys_lock);
+        file_write_at(file_page->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+        lock_release(&filesys_lock);
+        pml4_set_dirty(cur->pml4, page->va, false);
+    }
+    
+    // pml4에서 매핑 해제
+    pml4_clear_page(cur->pml4, page->va);
+    page->frame = NULL;
+    return true;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void file_backed_destroy(struct page* page)
 {
-    struct file_page* file_page UNUSED = &page->file;
+    struct file_page* file_page = &page->file;
+    struct thread* cur = thread_current();
+    
+    // 로드된 상태이고 dirty면 파일에 write back
+    if (page->frame != NULL && pml4_is_dirty(cur->pml4, page->va))
+    {
+        lock_acquire(&filesys_lock);
+        file_write_at(file_page->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+        lock_release(&filesys_lock);
+    }
+    
+    // pml4에서 매핑 해제
+    if (page->frame != NULL)
+        pml4_clear_page(cur->pml4, page->va);
+    
+    // frame 해제
+    if (page->frame != NULL)
+    {
+        palloc_free_page(page->frame->kva);
+        free(page->frame);
+        page->frame = NULL;
+    }
 }
 
 /* Do the mmap */
 void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t offset)
 {
+    struct thread* cur = thread_current();
+
+    // 1. file_reopen으로 독립적인 파일 참조 생성
+    lock_acquire(&filesys_lock);
+    struct file* reopened_file = file_reopen(file);
+    if (reopened_file == NULL) {
+        lock_release(&filesys_lock);
+        return NULL;
+    }
+    size_t file_len = file_length(reopened_file);
+    if (file_len == 0) {
+        lock_release(&filesys_lock);
+        return NULL;
+    }
+    lock_release(&filesys_lock);
+
+    // 실제 매핑할 길이는 파일 길이와 요청 길이 중 작은 값
+    size_t map_length = length < file_len ? length : file_len;
+
+    // 2. 페이지 수 계산
+    size_t page_cnt = map_length / PGSIZE + (map_length % PGSIZE != 0 ? 1 : 0);
+
+    // 3. overlap 검사: 기존 페이지와 겹치면 실패
+    for (size_t i = 0; i < page_cnt; i++)
+    {
+        void* va = addr + (i * PGSIZE);
+        if (spt_find_page(&cur->spt, va) != NULL)
+        {
+            lock_acquire(&filesys_lock);
+            file_close(reopened_file);
+            lock_release(&filesys_lock);
+            return NULL;
+        }
+    }
+
+    // 4. mmap_data 생성
+    struct mmap_data* m_data = malloc(sizeof(struct mmap_data));
+    if (m_data == NULL) {
+        lock_acquire(&filesys_lock);
+        file_close(reopened_file);
+        lock_release(&filesys_lock);
+        return NULL;
+    }
+
+    m_data->addr = addr;
+    m_data->page_cnt = page_cnt;
+    m_data->file = reopened_file;
+
+    // 5. 페이지 할당 루프 (lazy loading)
+    size_t remain_bytes = map_length;
+
+    for (size_t i = 0; i < page_cnt; i++)
+    {
+        void* va = addr + (i * PGSIZE);
+        size_t read_bytes = remain_bytes < PGSIZE ? remain_bytes : PGSIZE;
+        size_t zero_bytes = PGSIZE - read_bytes;
+
+        struct lazy_load_aux* aux = malloc(sizeof(struct lazy_load_aux));
+        if (aux == NULL) {
+            free(m_data);
+            lock_acquire(&filesys_lock);
+            file_close(reopened_file);
+            lock_release(&filesys_lock);
+            return NULL;
+        }
+
+        aux->file = reopened_file;
+        aux->ofs = offset + (i * PGSIZE);
+        aux->page_read_bytes = read_bytes;
+        aux->page_zero_bytes = zero_bytes;
+
+        if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, lazy_load_segment, aux))
+        {
+            free(aux);
+            free(m_data);
+            lock_acquire(&filesys_lock);
+            file_close(reopened_file);
+            lock_release(&filesys_lock);
+            return NULL;
+        }
+
+        remain_bytes -= read_bytes;
+    }
+
+    // 6. mmap_list에 추가 후 성공 반환
+    list_push_back(&cur->mmap_list, &m_data->mmap_elem);
+    return addr;
 }
 
 /* Do the munmap */
 void do_munmap(void* addr)
 {
+    struct thread* cur = thread_current();
+    struct mmap_data* m_data = NULL;
+
+    // 1. mmap_list에서 addr로 mmap_data 찾기
+    struct list_elem* e;
+    for (e = list_begin(&cur->mmap_list); e != list_end(&cur->mmap_list); e = list_next(e))
+    {
+        struct mmap_data* md = list_entry(e, struct mmap_data, mmap_elem);
+        if (md->addr == addr)
+        {
+            m_data = md;
+            break;
+        }
+    }
+
+    if (m_data == NULL)
+        return;
+
+    // 2. 페이지 해제 루프
+    for (size_t i = 0; i < m_data->page_cnt; i++)
+    {
+        void* va = addr + (i * PGSIZE);
+        struct page* page = spt_find_page(&cur->spt, va);
+
+        if (page == NULL)
+            continue;
+
+        // 페이지가 로드된 상태이고 dirty면 파일에 write back
+        if (page->frame != NULL && pml4_is_dirty(cur->pml4, va))
+        {
+            struct file_page* file_page = &page->file;
+            lock_acquire(&filesys_lock);
+            file_write_at(m_data->file, page->frame->kva, file_page->read_bytes, file_page->ofs);
+            lock_release(&filesys_lock);
+        }
+
+        // SPT에서 제거 (내부에서 destroy 호출됨)
+        spt_remove_page(&cur->spt, page);
+    }
+
+    // 3. file_close로 reopen한 파일 닫기
+    lock_acquire(&filesys_lock);
+    file_close(m_data->file);
+    lock_release(&filesys_lock);
+
+    // 4. mmap_list에서 제거 후 free
+    list_remove(&m_data->mmap_elem);
+    free(m_data);
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -130,8 +130,8 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         return NULL;
     }
     size_t available_len = file_len - offset;
-    /* 실제 매핑할 길이는 파일 길이와 요청 길이 중 작은 값 (offset 반영) */
-    size_t map_length = length < available_len ? length : available_len;
+    /* 실제 매핑할 길이는 요청 길이만큼 (파일보다 길면 0으로 채움) */
+    size_t map_length = length;
     lock_release(&filesys_lock);
 
     // 2. 페이지 수 계산
@@ -164,7 +164,9 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
     m_data->file = reopened_file;
 
     // 5. 페이지 할당 루프 (lazy loading)
-    size_t remain_bytes = map_length;
+    size_t remain_bytes = available_len > length ? length : available_len;
+    // remain_bytes는 파일에서 읽을 수 있는 유효 길이 (요청 길이와 파일 잔여 길이 중 작은 값)
+    
     size_t allocated_pages = 0;
 
     for (size_t i = 0; i < page_cnt; i++)
@@ -183,14 +185,17 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         aux->page_read_bytes = read_bytes;
         aux->page_zero_bytes = zero_bytes;
 
-        if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, lazy_load_segment, aux))
+        if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, file_backed_initializer, aux))
         {
             free(aux);
             goto mmap_fail;
         }
 
         allocated_pages++;
-        remain_bytes -= read_bytes;
+        if (remain_bytes >= PGSIZE)
+             remain_bytes -= PGSIZE;
+        else
+             remain_bytes = 0;
     }
     goto mmap_success;
 
@@ -252,6 +257,7 @@ void do_munmap(void* addr)
             lock_acquire(&filesys_lock);
             file_write_at(m_data->file, page->frame->kva, file_page->page_read_bytes, file_page->ofs);
             lock_release(&filesys_lock);
+            pml4_set_dirty(cur->pml4, va, false);
         }
 
         // SPT에서 제거 (내부에서 destroy 호출됨)

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -42,6 +42,7 @@ bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
     file_page->ofs = aux->ofs;
     file_page->page_read_bytes = aux->page_read_bytes;
     file_page->page_zero_bytes = aux->page_zero_bytes;
+    free(aux);
 
     return true;
 }

--- a/pintos/vm/file.c
+++ b/pintos/vm/file.c
@@ -42,7 +42,6 @@ bool file_backed_initializer(struct page* page, enum vm_type type, void* kva)
     file_page->ofs = aux->ofs;
     file_page->page_read_bytes = aux->page_read_bytes;
     file_page->page_zero_bytes = aux->page_zero_bytes;
-    free(aux);
 
     return true;
 }
@@ -186,7 +185,7 @@ void* do_mmap(void* addr, size_t length, int writable, struct file* file, off_t 
         aux->page_read_bytes = read_bytes;
         aux->page_zero_bytes = zero_bytes;
 
-        if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, file_backed_initializer, aux))
+        if (!vm_alloc_page_with_initializer(VM_FILE, va, writable, lazy_load_segment, aux))
         {
             free(aux);
             goto mmap_fail;

--- a/pintos/vm/uninit.c
+++ b/pintos/vm/uninit.c
@@ -58,7 +58,8 @@ static bool uninit_initialize(struct page* page, void* kva)
  * PAGE will be freed by the caller. */
 static void uninit_destroy(struct page* page)
 {
-    struct uninit_page* uninit UNUSED = &page->uninit;
-    /* TODO: Fill this function.
-     * TODO: If you don't have anything to do, just return. */
+    struct uninit_page* uninit = &page->uninit;
+    /* aux가 할당되어 있으면 해제 (lazy_load_aux 등) */
+    if (uninit->aux != NULL)
+        free(uninit->aux);
 }

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -1,8 +1,11 @@
 /* vm.c: Generic interface for virtual memory objects. */
 
 #include "threads/malloc.h"
+#include "threads/mmu.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "vm/file.h"
+#include "userprog/syscall.h"
 #include "hash.h"
 #include "threads/vaddr.h"
 #include "string.h"
@@ -72,7 +75,11 @@ bool vm_alloc_page_with_initializer(enum vm_type type, void* upage, bool writabl
         }
         uninit_new(p, upage, init, type, aux, page_initializer);
         p->writable = writable;
-        return spt_insert_page(spt, p);
+        if (!spt_insert_page(spt, p)) {
+            free(p);
+            return false;
+        }
+        return true;
     }
 err:
     return false;
@@ -183,9 +190,9 @@ bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write
         page = spt_find_page(spt, addr);
         if (page == NULL)
             return false;
-        if (write == 1 && page->writable == 0)
+        if (!vm_do_claim_page(page))
             return false;
-        return vm_do_claim_page(page);
+        return true;
     }
     return false;
 }
@@ -213,6 +220,8 @@ bool vm_claim_page(void* va)
 static bool vm_do_claim_page(struct page* page)
 {
     struct frame* frame = vm_get_frame();
+    if (frame == NULL)
+        return false;
 
     /* Set links */
     frame->page = page;
@@ -220,9 +229,22 @@ static bool vm_do_claim_page(struct page* page)
 
     /* TODO: Insert page table entry to map page's VA to frame's PA. */
     struct thread* current = thread_current();
-    pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
+    if (!pml4_set_page(current->pml4, page->va, frame->kva, page->writable)) {
+        palloc_free_page(frame->kva);
+        free(frame);
+        page->frame = NULL;
+        return false;
+    }
 
-    return swap_in(page, frame->kva);
+    if (!swap_in(page, frame->kva)) {
+        /* swap_in 실패 시 정리 */
+        pml4_clear_page(current->pml4, page->va);
+        palloc_free_page(frame->kva);
+        free(frame);
+        page->frame = NULL;
+        return false;
+    }
+    return true;
 }
 
 uint64_t page_hash(const struct hash_elem* hash_e, void* aux)
@@ -270,26 +292,48 @@ bool supplemental_page_table_copy(struct supplemental_page_table* dst, struct su
             if (final_type == VM_FILE)
                 continue;
             if (src_uninit->aux != NULL) {
-                struct lazy_load_aux* copy_aux = malloc(sizeof(struct lazy_load_aux));
+                struct file_page* copy_aux = malloc(sizeof(struct file_page));
                 if (copy_aux == NULL)
-                    return false;
-                memcpy(copy_aux, src_uninit->aux, sizeof(struct lazy_load_aux));
-                if (!vm_alloc_page_with_initializer(src_uninit->type, upage, writable, src_uninit->init, copy_aux))
-                    return false;
+                    goto err;
+                memcpy(copy_aux, src_uninit->aux, sizeof(struct file_page));
+                
+                // lazy_load_segment의 경우 file 객체를 reopen하여 독립적인 참조 생성
+                if (src_uninit->init == lazy_load_segment) {
+                    copy_aux->file = file_reopen(copy_aux->file);
+                    if (copy_aux->file == NULL) {
+                        free(copy_aux);
+                        goto err;
+                    }
+                }
+
+                if (!vm_alloc_page_with_initializer(src_uninit->type, upage, writable, src_uninit->init, copy_aux)) {
+                    if (src_uninit->init == lazy_load_segment) {
+                        lock_acquire(&filesys_lock);
+                        file_close(copy_aux->file);
+                        lock_release(&filesys_lock);
+                    }
+                    free(copy_aux);
+                    goto err;
+                }
             } else {
                 if (!vm_alloc_page(src_uninit->type, upage, writable))
-                    return false;
+                    goto err;
             }
             continue;
         }
         if (!vm_alloc_page(src_type, upage, writable))
-            return false;
+            goto err;
         if (!vm_claim_page(upage))
-            return false;
+            goto err;
         struct page* dst_page = spt_find_page(dst, upage);
         memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);
     }
     return true;
+
+err:
+    /* 실패 시 이미 복사된 페이지들 정리 */
+    supplemental_page_table_kill(dst);
+    return false;
 }
 
 /* Free the resource hold by the supplemental page table */

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -104,8 +104,8 @@ bool spt_insert_page(struct supplemental_page_table* spt, struct page* page)
 
 void spt_remove_page(struct supplemental_page_table* spt, struct page* page)
 {
+    hash_delete(&spt->hash_table, &page->hash_elem);
     vm_dealloc_page(page);
-    return true;
 }
 
 /* Get the struct frame, that will be evicted. */
@@ -225,7 +225,7 @@ static bool vm_do_claim_page(struct page* page)
     return swap_in(page, frame->kva);
 }
 
-unsigned page_hash(const struct hash_elem* hash_e, void* aux)
+uint64_t page_hash(const struct hash_elem* hash_e, void* aux)
 {
     struct page* page = hash_entry(hash_e, struct page, hash_elem);
     return hash_bytes(&page->va, sizeof(page->va));
@@ -256,8 +256,19 @@ bool supplemental_page_table_copy(struct supplemental_page_table* dst, struct su
         enum vm_type src_type = VM_TYPE(src_page->operations->type);
         void* upage = src_page->va;
         bool writable = src_page->writable;
+        
+        // 기본 과제에서는 mmap 상속 불필요. 
+        // 단, extra(cow) 구현 시에는 이 continue를 제거하고 
+        // 파일 객체 복제(file_reopen) 및 페이지 공유(Read-Only Mapping) 로직으로 대체해야 함.
+        if (src_type == VM_FILE)
+            continue;
+        
         if (src_type == VM_UNINIT) {
             struct uninit_page* src_uninit = &src_page->uninit;
+            // VM_FILE로 바뀔 UNINIT 페이지도 복사하지 않음
+            enum vm_type final_type = VM_TYPE(src_uninit->type);
+            if (final_type == VM_FILE)
+                continue;
             if (src_uninit->aux != NULL) {
                 struct lazy_load_aux* copy_aux = malloc(sizeof(struct lazy_load_aux));
                 if (copy_aux == NULL)

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -1,8 +1,10 @@
 /* vm.c: Generic interface for virtual memory objects. */
 
+#include "filesys/file.h"
 #include "threads/malloc.h"
 #include "threads/mmu.h"
 #include "vm/vm.h"
+#include "threads/synch.h"
 #include "vm/inspect.h"
 #include "vm/file.h"
 #include "userprog/syscall.h"
@@ -10,6 +12,7 @@
 #include "threads/vaddr.h"
 #include "string.h"
 #include "userprog/process.h"
+#include <stdint.h>
 #define STACK_MAX_SIZE (1 << 20)
 
 /* Initializes the virtual memory subsystem by invoking each subsystem's
@@ -180,7 +183,7 @@ bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write
     if (is_kernel_vaddr(addr))
         return false;
     if (not_present) {
-        void* rsp = f->rsp;
+        uintptr_t rsp = f->rsp;
         if (!user)
             rsp = thread_current()->rsp;
         if ((USER_STACK - STACK_MAX_SIZE <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) ||
@@ -193,7 +196,8 @@ bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write
             if (write && !page->writable)
                 return false;
             if (!vm_do_claim_page(page))
-                return false;        return true;
+                return false;        
+            return true;
     }
     return false;
 }
@@ -297,10 +301,11 @@ bool supplemental_page_table_copy(struct supplemental_page_table* dst, struct su
                 if (copy_aux == NULL)
                     goto err;
                 memcpy(copy_aux, src_uninit->aux, sizeof(struct file_page));
-                
-                // lazy_load_segment의 경우 file 객체를 reopen하여 독립적인 참조 생성
+                // fork할때, lazy_load_segment의 경우 exec_file 객체를 duplicate하여 독립적인 참조 생성
                 if (src_uninit->init == lazy_load_segment) {
-                    copy_aux->file = file_reopen(copy_aux->file);
+                    lock_acquire(&filesys_lock);
+                    copy_aux->file = file_duplicate(copy_aux->file);
+                    lock_release(&filesys_lock);
                     if (copy_aux->file == NULL) {
                         free(copy_aux);
                         goto err;

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -301,17 +301,6 @@ bool supplemental_page_table_copy(struct supplemental_page_table* dst, struct su
                 if (copy_aux == NULL)
                     goto err;
                 memcpy(copy_aux, src_uninit->aux, sizeof(struct file_page));
-                // fork할때, lazy_load_segment의 경우 exec_file 객체를 duplicate하여 독립적인 참조 생성
-                if (src_uninit->init == lazy_load_segment) {
-                    lock_acquire(&filesys_lock);
-                    copy_aux->file = file_duplicate(copy_aux->file);
-                    lock_release(&filesys_lock);
-                    if (copy_aux->file == NULL) {
-                        free(copy_aux);
-                        goto err;
-                    }
-                }
-
                 if (!vm_alloc_page_with_initializer(src_uninit->type, upage, writable, src_uninit->init, copy_aux)) {
                     if (src_uninit->init == lazy_load_segment) {
                         lock_acquire(&filesys_lock);

--- a/pintos/vm/vm.c
+++ b/pintos/vm/vm.c
@@ -187,12 +187,13 @@ bool vm_try_handle_fault(struct intr_frame* f, void* addr, bool user, bool write
             (USER_STACK - STACK_MAX_SIZE <= rsp && rsp <= addr && addr <= USER_STACK))
             vm_stack_growth(addr);
 
-        page = spt_find_page(spt, addr);
-        if (page == NULL)
-            return false;
-        if (!vm_do_claim_page(page))
-            return false;
-        return true;
+            page = spt_find_page(spt, addr);
+            if (page == NULL)
+                return false;
+            if (write && !page->writable)
+                return false;
+            if (!vm_do_claim_page(page))
+                return false;        return true;
     }
     return false;
 }


### PR DESCRIPTION
## 변경 사항

  구현 내용
   - Memory Mapped File (mmap/munmap) 시스템 콜 구현:
     - do_mmap: 파일 데이터를 Lazy Loading 방식으로 메모리에 매핑. 가상 주소 정렬 검사 및 오버랩 체크 포함.
     - do_munmap: 매핑 해제 시 Dirty 페이지를 디스크 파일에 Write-back 수행 후 자원 정리.
     - mmap 해제 시 닫힌 파일 접근 방지를 위해 file_reopen을 통한 파일 객체 독립성 확보.
   - VM 시스템 확장 및 안정화:
     - lazy_load_segment를 전역화하여 실행 파일 로딩과 mmap 로딩 로직 통합.
     - File-Backed Page(VM_FILE) 생명주기 관리(initializer, swap_in, swap_out, destroy) 구현.
     - 프로세스 종료(process_exit) 시 열려있는 모든 mmap 자동 해제 로직 추가.
  
  변경된 파일
   - pintos/vm/vm.c
     - supplemental_page_table_copy: file_duplicate 도입 및 Lock 보호 추가로 fork 안정성 확보.
     - vm_file_init: File-Backed VM 서브시스템 초기화.
     - vm_alloc_page_with_initializer: mmap 및 Lazy Loading을 위한 페이지 할당 인터페이스 개선.
   - pintos/vm/file.c
     - do_mmap: 주소 검증, 페이지 단위 할당, Lazy Loading 설정 구현.
     - do_munmap: 페이지 Dirty 체크, 파일 Write-back, SPT 제거 로직 구현.
     - file_backed_swap_in/out: 디스크-메모리 간 데이터 동기화 및 Lock 처리.
     - file_backed_destroy: 페이지 해제 시 Write-back 및 프레임 반환.
   - pintos/userprog/syscall.c
     - mmap, munmap 시스템 콜 핸들러 연결 및 1차 파라미터 검증 로직 추가.

  체크리스트
   - [x] 코드 스타일 가이드 준수
   - [x] 불필요한 주석/디버깅 코드 제거
   - [x] 커밋 메시지 컨벤션 준수
   - [x] 관련 테스트 통과 확인

  추가 설명